### PR TITLE
allow user to select subnet (private or internal) and add OPA deletio…

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -99,11 +99,12 @@ params:
       title: Secure cluster with an auth token and TLS encryption
       description: "Secure cluster with an auth token and TLS encryption (Required for most security compliance audits eg. HIPAA). NOTE: Changing this will recreate the cluster."
       default: true
-    allow_vpc_access:
-      title: Allow VPC Access
-      description: Allow the entire VPC to access the Redis instance.
-      type: boolean
-      default: true
+    subnet_type:
+      title: Subnet Type
+      description: Deploy Redis to internal subnets (cannot reach the internet) or private subnets (internet egress traffic allowed)
+      type: string
+      enum: [internal, private]
+      default: internal
 
 connections:
   required:
@@ -130,7 +131,7 @@ ui:
     - cluster_mode_enabled
     - node_groups
     - secure
-    - allow_vpc_access
+    - subnet_type
     - "*"
   node_groups:
     condition: cluster_mode_enabled=true

--- a/src/validations.json
+++ b/src/validations.json
@@ -1,0 +1,5 @@
+{
+    "do_not_delete": [
+        "aws_elasticache_replication_group.main"
+    ]
+}


### PR DESCRIPTION
This allows the selection of private or internal subnets.

FYI, once we do this change, there is no going back on internal subnets. If we want to standardize on all DB/datastores going in private (instead of internal) then that change would be the MSK change I sent out last week and we would probably remove internal from the VPC.